### PR TITLE
fix: CUDA 12 미만일 때 TensorRT 대신 PyTorch(.pt)로 폴백

### DIFF
--- a/backend/monitor_bridge.py
+++ b/backend/monitor_bridge.py
@@ -122,9 +122,18 @@ def _build_monitor(cam_source: str, conf_helmet: float, conf_vest: float):
         import workplace_safety_monitor as wsm  # noqa: F401
 
         # Prefer TensorRT engine if available (significantly faster)
+        # TensorRT engines require CUDA ≥ 12; fall back to .pt on older versions
+        _cuda_ok = torch.cuda.is_available()
+        _cuda_major = int(torch.version.cuda.split(".")[0]) if _cuda_ok and torch.version.cuda else 0
+        _use_engine = _cuda_ok and _cuda_major >= 12
+
         def _find_model(stem: str) -> str:
             engine = BASE_DIR / f"{stem}.engine"
-            return str(engine) if engine.exists() else str(BASE_DIR / f"{stem}.pt")
+            if _use_engine and engine.exists():
+                return str(engine)
+            if not _use_engine and engine.exists():
+                logger.info("TensorRT engine found but CUDA %s < 12 — using .pt fallback", torch.version.cuda)
+            return str(BASE_DIR / f"{stem}.pt")
 
         person_model = _find_model("yolo12n")
         ppe_model    = _find_model("best")

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -11,3 +11,4 @@ numpy>=1.21.0
 ultralytics>=8.0.0
 torch>=1.13.0
 torchvision>=0.14.0
+tensorrt>=8.6.0


### PR DESCRIPTION
## 변경 요약
- CUDA 12 미만 환경에서 TensorRT `.engine` 대신 PyTorch `.pt` 모델로 자동 폴백

## 관련 이슈
- Closes #3

## 변경 내용
- `backend/monitor_bridge.py`의 `_find_model()` 함수에 CUDA 메이저 버전 체크 로직 추가
- CUDA < 12이면 TensorRT 파일인 `.engine` 파일을 무시하고, Pytorch 파일인 `.pt` 사용
- 폴백 시 CUDA 버전과 함께 로그 메시지 출력

## 테스트
- [x] 로컬 실행 (백엔드)
- [x] 로컬 실행 (프론트)
- [x] 주요 시나리오 확인:
  - CUDA ≥ 12 환경에서 `.engine` 정상 로드
  - CUDA < 12 환경에서 `.pt` 폴백 동작
  - CUDA 미설치(CPU only) 환경에서 `.pt` 정상 동작

## 스크린샷/녹화(선택)
- 해당 없음

## 체크리스트
- [x] 영향 범위(사용자/권한/성능/보안) 검토
- [x] 실패 시 롤백/대안 고려(필요 시)
- [ ] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시)