### PR TITLE
fix: 스냅샷 썸네일이 표시되지 않는 버그 수정

### DIFF
--- a/frontend/src/pages/Violations.tsx
+++ b/frontend/src/pages/Violations.tsx
@@ -5,15 +5,34 @@ import type { Violation, Camera } from '../types'
 
 function SnapshotThumb({ violationId }: { violationId: number }) {
   const [open, setOpen] = useState(false)
-  const url = snapshotUrl(violationId)
+  const [blobUrl, setBlobUrl] = useState<string | null>(null)
+
+  useEffect(() => {
+    const token = localStorage.getItem('token')
+    fetch(snapshotUrl(violationId), {
+      headers: token ? { Authorization: `Bearer ${token}` } : {},
+    })
+      .then((res) => {
+        if (!res.ok) throw new Error('snapshot fetch failed')
+        return res.blob()
+      })
+      .then((blob) => setBlobUrl(URL.createObjectURL(blob)))
+      .catch(() => setBlobUrl(null))
+
+    return () => {
+      if (blobUrl) URL.revokeObjectURL(blobUrl)
+    }
+  }, [violationId])
+
+  if (!blobUrl) return null
+
   return (
     <>
       <img
-        src={url}
+        src={blobUrl}
         alt="스냅샷"
         className="w-12 h-9 object-cover rounded cursor-pointer border border-gray-700 hover:border-gray-400 transition-colors"
         onClick={() => setOpen(true)}
-        onError={(e) => { (e.currentTarget as HTMLImageElement).style.display = 'none' }}
       />
       {open && (
         <div
@@ -21,7 +40,7 @@ function SnapshotThumb({ violationId }: { violationId: number }) {
           onClick={() => setOpen(false)}
         >
           <img
-            src={url}
+            src={blobUrl}
             alt="스냅샷 전체"
             className="max-w-[90vw] max-h-[90vh] rounded shadow-2xl border border-gray-600"
             onClick={(e) => e.stopPropagation()}


### PR DESCRIPTION
## 변경 요약
- 위반 이력 페이지에서 스냅샷 썸네일이 표시되지 않는 버그 수정

## 관련 이슈
- Closes #7

## 변경 내용
- `<img src>` 방식은 Authorization 헤더를 포함할 수 없어 401 에러 발생
- `fetch()` + blob URL 방식으로 변경하여 JWT 인증을 유지하면서 이미지 표시

## 테스트
- [x] 로컬 실행 (백엔드)
- [x] 로컬 실행 (프론트)
- [x] 주요 시나리오 확인:
  - [x] 위반 이력 페이지에서 스냅샷 썸네일 표시 확인
  - [x] 썸네일 클릭 시 전체 이미지 모달 표시 확인

## 스크린샷/녹화(선택)
- 

## 체크리스트
- [x] 영향 범위(사용자/권한/성능/보안) 검토
- [ ] 실패 시 롤백/대안 고려(필요 시)
- [ ] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시)