### PR TITLE
style!: backend CUDA 사용

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,4 +1,4 @@
---extra-index-url https://download.pytorch.org/whl/cu124
+--extra-index-url https://download.pytorch.org/whl/cu128
 aiofiles>=23.0.0
 aiosqlite>=0.20.0
 bcrypt>=4.0.0
@@ -9,7 +9,7 @@ python-jose[cryptography]>=3.3.0
 python-multipart>=0.0.9
 sqlalchemy>=2.0.0
 tensorrt>=8.6.0
-torch==2.5.1+cu124
-torchvision==0.20.1+cu124
+torch==2.10.0+cu128
+torchvision==0.25.0+cu128
 ultralytics>=8.0.0
 uvicorn[standard]>=0.29.0

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,14 +1,15 @@
-fastapi>=0.111.0
-uvicorn[standard]>=0.29.0
-sqlalchemy>=2.0.0
-aiosqlite>=0.20.0
-python-jose[cryptography]>=3.3.0
-bcrypt>=4.0.0
-python-multipart>=0.0.9
+--extra-index-url https://download.pytorch.org/whl/cu124
 aiofiles>=23.0.0
-opencv-python>=4.8.0
+aiosqlite>=0.20.0
+bcrypt>=4.0.0
+fastapi>=0.111.0
 numpy>=1.21.0
-ultralytics>=8.0.0
-torch>=1.13.0
-torchvision>=0.14.0
+opencv-python>=4.8.0
+python-jose[cryptography]>=3.3.0
+python-multipart>=0.0.9
+sqlalchemy>=2.0.0
 tensorrt>=8.6.0
+torch==2.5.1+cu124
+torchvision==0.20.1+cu124
+ultralytics>=8.0.0
+uvicorn[standard]>=0.29.0


### PR DESCRIPTION
## 현재 문제점

`--extra-index-url` 없는 `requirements.txt`는 CPU만 사용하는 버전의 PyTorch를 설치하도록 되어 있음.

PyTorch가 CPU만 사용할 시, 영상 처리 속도가 매우 느려져 정상적인 영상 처리 및 모델 탐지가 불가능하게 됨.

따라서 GPU(CUDA)를 사용하는 버전의 PyTorch를 설치하도록 지시해야 함.

## 변경 요약

- `backend/requirements.txt`에 CUDA 사용하는 PyTorch 버전 명시  
  `--extra-index-url https://download.pytorch.org/whl/cu128`와 `+cu128`가 없으면 CPU만 사용하는 PyTorch를 다운로드받게 됨
- `torch`, `torchvision`의 버전을 공식 지원되는 최신 버전으로 업그레이드

## 변경 내용
- BREAKING CHANGE: CUDA 12.8.1 사용 강제
