### PR TITLE
fix: TensorRT 엔진 호환 실패치 .pt 가중치 fallback

### DIFF
--- a/backend/monitor_bridge.py
+++ b/backend/monitor_bridge.py
@@ -167,7 +167,24 @@ def _build_monitor(cam_source: str, conf_helmet: float, conf_vest: float):
         logger.info("YOLO monitor built successfully (device=%s)", device)
         return monitor
     except Exception as exc:
-        logger.warning("Could not build Monitor — raw frames only", exc_info=True)
+        logger.warning("Could not build Monitor with TensorRT engine; trying PyTorch .pt fallback", exc_info=True)
+
+        # Fallback to .pt if .engine exists but is incompatible with TensorRT version
+        fallback_person = str(BASE_DIR / "yolo12n.pt")
+        fallback_ppe = str(BASE_DIR / "best.pt")
+        if Path(fallback_person).exists() and Path(fallback_ppe).exists():
+            logger.info("Found .pt fallbacks: person=%s ppe=%s", fallback_person, fallback_ppe)
+            args.person_weights = fallback_person
+            args.ppe_weights = fallback_ppe
+            try:
+                monitor = wsm.Monitor(args)
+                device = "cuda" if torch.cuda.is_available() else "cpu"
+                logger.info("YOLO monitor built with .pt fallback (device=%s)", device)
+                return monitor
+            except Exception:
+                logger.warning("Failed to build Monitor with .pt fallback as well", exc_info=True)
+
+        logger.warning("Could not build Monitor — raw frames only after fallback")
         return None
 
 


### PR DESCRIPTION
## 변경 요약
- monitor_bridge.py에서 TensorRT 엔진 우선 로드 로직에 CUDA 버전 체크 추가
- CUDA 12 미만에서는 `.engine` 대신 `.pt` 모델 사용하도록 fallback 처리
- 하위 CUDA 환경에서 비호환으로 인한 실행 중단 문제 해결

## 관련 이슈
- Closes # (관련 이슈 번호 추가)

## 변경 내용
- `_build_monitor` 내부:
  - `_cuda_ok = torch.cuda.is_available()`
  - `_cuda_major = int(torch.version.cuda.split(".")[0]) if _cuda_ok and torch.version.cuda else 0`
  - `_use_engine = _cuda_ok and _cuda_major >= 12`
- `_find_model(stem)` 수정:
  - `stem.engine` 존재할 때 `_use_engine`이면 `.engine` 반환
  - `_use_engine` False이면 로그 (“TensorRT engine found but CUDA < 12 — using .pt fallback”) 후 `.pt` 반환
  - `.engine` 없으면 `.pt` 반환

## 테스트
- [x] 로컬 실행 (백엔드) : `python backend/main.py` 또는 실제 모니터링 실행 확인
- [ ] 로컬 실행 (프론트)
- [x] 주요 시나리오 확인:
  - CUDA 12 이상 환경 + yolo12n.engine 존재 → `.engine` 사용
  - CUDA 12 미만 환경 + yolo12n.engine 존재 → `.pt` fallback
  - yolo12n.engine 미존재 → `.pt` 사용

## 스크린샷/녹화(선택)
- (옵션) 콘솔 로그에서 fallback 메시지 캡처 또는 정상 탐지 동작 화면 기록

## 체크리스트
- [x] 영향 범위(사용자/권한/성능/보안) 검토
  - 사용자: 하위 CUDA 시스템 호환성 개선
  - 성능: CUDA 12 미만에서 TensorRT 성능 미사용, 정상 동작 우선
- [x] 실패 시 롤백/대안 고려(필요 시)
  - fallback 로직 장애 시 기존 `.engine` 우선 로직으로 리버트
- [x] 문서/환경변수/마이그레이션 변경 사항 반영(해당 시)
  - README/운영 문서에 CUDA 버전 요구사항 및 fallback 설명 추가 권장